### PR TITLE
Bug: libLibStoryBoard.a file contains no debug symbols 

### DIFF
--- a/libstoryboard/include/storyboard/storyboard.hpp
+++ b/libstoryboard/include/storyboard/storyboard.hpp
@@ -1,10 +1,8 @@
 #ifndef _STORYBOARD_HPP_
 #define _STORYBOARD_HPP_
 
-#include <vector>
-#include <algorithm>
-#include <iostream>
 #include <string>
+#include <vector>
 
 namespace storyboard{
 
@@ -46,23 +44,12 @@ public:
      * @param[in] other : Compared object
      * @return true if contents of this object are the same as those of the input object, otherwise return false
     */
-    bool operator==(const Note& other)
-    {
-        return (m_title == other.m_title) && (m_text == other.m_text) && (m_tags == other.m_tags);
-    }
+    bool operator==(const Note& other);
 
     /**
      * @brief print note data into std::cout
      */
-    void printMe()
-    {
-        std::cout << "Title: " << m_title << std::endl;
-        std::cout << "Text: " << m_text << std::endl;
-        std::cout << "Tags: ";
-        for( auto& tag : m_tags )
-        { std::cout << tag << ", "; }
-        std::cout << std::endl;
-    }
+    void printMe();
     
     std::string m_title; /// Title of the note-object
     std::string m_text;  /// Text of the note-object
@@ -82,86 +69,46 @@ public:
      * @brief Adds a new note object into the Storyboard
      * @param[in] : newNote note to be added into the Storyboard
     */
-    void addNote( const Note& newNote )
-    {
-        m_notes.push_back( newNote );
-    }
+    void addNote( const Note& newNote );
 
     /**
      * @brief Adds a new note object into the Storyboard. Uses move semantics (i.e. steals the resources from the given object)
      * @param[in] : newNote note to be added into the Storyboard
     */
-    void addNote( Note&& newNote )
-    {
-        m_notes.push_back( std::move(newNote) );
-    }
+    void addNote( Note&& newNote );
 
     /**
      * @brief Removes a note from the Storyboard
      * @param[in] deleteMe : Sample of a Note object to be deleted from the Storyboard. Note objects that are equal to deleteMe will be deleted.
      * @return number of elements that were deleted
     */
-    int deleteNote( const Note& deleteMe )
-    {
-        int nr_elem = m_notes.size();
-        m_notes.erase( std::remove( m_notes.begin(), m_notes.end(), deleteMe ), m_notes.end() );
-        return nr_elem - m_notes.size();
-    }
+    int deleteNote( const Note& deleteMe );
     
     /**
      * @brief Search the Storyboard for notes that contain the given string in the title field
      * @param[in] title : string that is matched
      * @param[in,out] container : notes in the Storyboard that contain the matched field are added into this container
     */
-    int searchByTitle( const std::string& title, t_note_cont& container )
-    {
-        int len = container.size();
-        std::copy_if(m_notes.begin(), m_notes.end(), std::back_inserter(container), [&title](const Note& cmp){return cmp.m_title == title;} );
-        
-        return container.size() - len;
-    }
+    int searchByTitle( const std::string& title, t_note_cont& container );
     
     /**
      * @brief Search the Storyboard container for notes that contain the given string in the text field
      * @param[in] title : string that is matched
      * @param[in,out] container : notes in the Storyboard that contain the matched field are added into this container
     */
-    int searchByText( const std::string& text, t_note_cont& container )
-    {
-        int len = container.size();
-        std::copy_if(m_notes.begin(), m_notes.end(), std::back_inserter(container), [&text](const Note& cmp){ return cmp.m_text == text;} );
-        
-        return container.size() - len;
-    }
+    int searchByText( const std::string& text, t_note_cont& container );
 
     /**
      * @brief Search the Storyboard container for notes that contain the given string(s) in the tag field
      * @param[in] title : string that is matched
      * @param[in,out] container : notes in the Storyboard that contain the matched field are added into this container
     */
-    int searchByTag( const t_tag_cont& tags, t_note_cont& container )
-    {
-        int len = container.size();
-        std::copy_if(m_notes.begin(), m_notes.end(), std::back_inserter(container), [&tags](const Note& cmp){ return cmp.m_tags == tags;} );
-        
-        return container.size() - len;
-    }
+    int searchByTag( const t_tag_cont& tags, t_note_cont& container );
 
     /**
      * @brief prints contents of the Storyboard into std::cout
     */
-    void print()
-    {
-        for( auto& note : m_notes )
-        {
-            std::cout << "Title: " << note.m_title << std::endl;
-            std::cout << "Text: " << note.m_text << std::endl;
-            std::cout << "Tags: ";
-            for( auto& tag : note.m_tags )
-            { std::cout << tag << " "; }
-            std::cout << std::endl << "--------" << std::endl;
-        }
-    }
+    void print();
 
 private:
     t_note_cont m_notes; ///Container of Note objects

--- a/libstoryboard/src/storyboard.cpp
+++ b/libstoryboard/src/storyboard.cpp
@@ -1,0 +1,77 @@
+#include <algorithm>
+#include <iostream>
+
+#include <storyboard/storyboard.hpp>
+
+namespace storyboard {
+
+bool Note::operator==(const Note& other)
+{
+    return (m_title == other.m_title) && (m_text == other.m_text) && (m_tags == other.m_tags);
+}
+
+void Note::printMe()
+{
+    std::cout << "Title: " << m_title << std::endl;
+    std::cout << "Text: " << m_text << std::endl;
+    std::cout << "Tags: ";
+    for( auto& tag : m_tags )
+    { std::cout << tag << ", "; }
+    std::cout << std::endl;
+}
+
+void Storyboard::addNote( const Note& newNote )
+{
+    m_notes.push_back( newNote );
+}
+
+void Storyboard::addNote( Note&& newNote )
+{
+    m_notes.push_back( std::move(newNote) );
+}
+
+int Storyboard::deleteNote( const Note& deleteMe )
+{
+    int nr_elem = m_notes.size();
+    m_notes.erase( std::remove( m_notes.begin(), m_notes.end(), deleteMe ), m_notes.end() );
+    return nr_elem - m_notes.size();
+}
+
+int Storyboard::searchByTitle( const std::string& title, t_note_cont& container )
+{
+    int len = container.size();
+    std::copy_if(m_notes.begin(), m_notes.end(), std::back_inserter(container), [&title](const Note& cmp){return cmp.m_title == title;} );
+    
+    return container.size() - len;
+}
+
+int Storyboard::searchByText( const std::string& text, t_note_cont& container )
+{
+    int len = container.size();
+    std::copy_if(m_notes.begin(), m_notes.end(), std::back_inserter(container), [&text](const Note& cmp){ return cmp.m_text == text;} );
+    
+    return container.size() - len;
+}
+
+int Storyboard::searchByTag( const t_tag_cont& tags, t_note_cont& container )
+{
+    int len = container.size();
+    std::copy_if(m_notes.begin(), m_notes.end(), std::back_inserter(container), [&tags](const Note& cmp){ return cmp.m_tags == tags;} );
+    
+    return container.size() - len;
+}
+
+void Storyboard::print()
+{
+    for( auto& note : m_notes )
+    {
+        std::cout << "Title: " << note.m_title << std::endl;
+        std::cout << "Text: " << note.m_text << std::endl;
+        std::cout << "Tags: ";
+        for( auto& tag : note.m_tags )
+        { std::cout << tag << " "; }
+        std::cout << std::endl << "--------" << std::endl;
+    }
+}
+
+} //End of namespace storyboard


### PR DESCRIPTION
**what does this PR do?**
Moves implementation into storyboard.cpp from header file.

As things are, libstoryboard is effectively header-only and `libLibStoryBoard.a` contains no symbols:
```bash
$ nm libLibStoryBoard.a
  storyboard.cpp.o:
```

And line 20 in `executable/CMakeLists.tx`t:
`target_link_libraries (executable LibStoryBoard::LibStoryBoard)`
has no effect and can be removed.

With these changes `libLibStoryBoard.a` contains symbols and removing line 20 results in build errors:
`undefined reference to storyboard::Storyboard::addNote(storyboard::Note const&)'`